### PR TITLE
fix: correct handling of conditional responses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,14 @@ export function createIPXHandler ({
       typeof res.body === 'string' ? res.body : res.body.toString('base64')
 
     res.headers.etag = responseEtag || etag(body)
+    delete res.headers['Last-Modified']
 
+    if (requestEtag && requestEtag === res.headers.etag) {
+      return {
+        statusCode: 304,
+        message: 'Not Modified'
+      }
+    }
     return {
       statusCode: res.statusCode,
       message: res.statusMessage,


### PR DESCRIPTION
The Netlify proxy won't return a 304 Not Modified response if the browser sends both `If-None-Match` and `If-Modified-Since` headers. To work around this, this PR prevents the function returning a `Last-Modified` header, meaning the browser won't send `If-Modified-Since`