### PR TITLE
ci: enable renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>netlify/renovate-config"]
+  "extends": ["local>netlify/renovate-config"],
+  "includeForks": true
 }


### PR DESCRIPTION
By default, renovate doesn't run on forks. This PR enables it.