### PR TITLE
fix: remove content-type check

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -114,18 +114,6 @@ export async function loadSourceImage ({ cacheDir, url, requestEtag, modifiers, 
       }
     }
   }
-  const contentType = response.headers.get('content-type')
-  if (contentType && !contentType.startsWith('image/')) {
-    return {
-      response: {
-        statusCode: GATEWAY_ERROR,
-        headers: {
-          'Content-Type': 'text/plain'
-        },
-        body: 'Source is not an image'
-      }
-    }
-  }
 
   const outfile = createWriteStream(inputCacheFile)
   await new Promise((resolve, reject) => {


### PR DESCRIPTION
Currently we check if the server returning a source image is sending an image mimetype. This was meant to handle cases where the URL was incorrect and it was sending somethign other than an image. However this caused too many false positives, so it's better to just remove it and let sharp throw the error if the file is incorrect.

Closes #10 