### PR TITLE
fix: remote patterns logic

### DIFF
--- a/example/netlify/functions/ipx.ts
+++ b/example/netlify/functions/ipx.ts
@@ -7,5 +7,8 @@ export const handler = createIPXHandler({
       hostname: '*.unsplash.com'
     }
   ],
+  domains: [
+    'netlify.com'
+  ],
   basePath: '/.netlify/builders/ipx/'
 })

--- a/example/netlify/functions/ipx.ts
+++ b/example/netlify/functions/ipx.ts
@@ -8,7 +8,7 @@ export const handler = createIPXHandler({
     }
   ],
   domains: [
-    'netlify.com'
+    'www.netlify.com'
   ],
   basePath: '/.netlify/builders/ipx/'
 })

--- a/example/public/index.html
+++ b/example/public/index.html
@@ -20,10 +20,17 @@
       <figcaption>
   </figure>
   <figure>
-  <img
-    src="/_gatsby/image/aHR0cHM6Ly9pbWFnZXMudW5zcGxhc2guY29tL3Bob3RvLTE1MTc4NDk4NDU1MzctNGQyNTc5MDI0NTRhP2l4bGliPXJiLTEuMi4xJml4aWQ9TW53eE1qQTNmREI4TUh4d2FHOTBieTF3WVdkbGZIeDhmR1Z1ZkRCOGZIeDgmYXV0bz1mb3JtYXQmZml0PWNyb3Amdz0yMDAwJnE9ODA=/dz0zMDAmaD00MDAmZm09YXZpZg==.avif"
-    alt="Gatsby" />
-    <figcaption>/_gatsby/image/aHR0cHM6Ly9pbWFnZXMudW5zcGxhc2guY29tL3Bob3RvLTE1MTc4NDk4NDU1MzctNGQyNTc5MDI0NTRhP2l4bGliPXJiLTEuMi4xJml4aWQ9TW53eE1qQTNmREI4TUh4d2FHOTBieTF3WVdkbGZIeDhmR1Z1ZkRCOGZIeDgmYXV0bz1mb3JtYXQmZml0PWNyb3Amdz0yMDAwJnE9ODA=/dz0zMDAmaD00MDAmZm09YXZpZg==.avif</figcaption>
+    <img src="/.netlify/builders/ipx/f_webp,w_146/https://www.netlify.com/img/deploy/button.svg" />
+    <figcaption>/.netlify/builders/ipx/f_webp,w_146/img/https://www.netlify.com/img/deploy/button.svg
+      <figcaption>
+  </figure>
+  <figure>
+    <img
+      src="/_gatsby/image/aHR0cHM6Ly9pbWFnZXMudW5zcGxhc2guY29tL3Bob3RvLTE1MTc4NDk4NDU1MzctNGQyNTc5MDI0NTRhP2l4bGliPXJiLTEuMi4xJml4aWQ9TW53eE1qQTNmREI4TUh4d2FHOTBieTF3WVdkbGZIeDhmR1Z1ZkRCOGZIeDgmYXV0bz1mb3JtYXQmZml0PWNyb3Amdz0yMDAwJnE9ODA=/dz0zMDAmaD00MDAmZm09YXZpZg==.avif"
+      alt="Gatsby" />
+    <figcaption>
+      /_gatsby/image/aHR0cHM6Ly9pbWFnZXMudW5zcGxhc2guY29tL3Bob3RvLTE1MTc4NDk4NDU1MzctNGQyNTc5MDI0NTRhP2l4bGliPXJiLTEuMi4xJml4aWQ9TW53eE1qQTNmREI4TUh4d2FHOTBieTF3WVdkbGZIeDhmR1Z1ZkRCOGZIeDgmYXV0bz1mb3JtYXQmZml0PWNyb3Amdz0yMDAwJnE9ODA=/dz0zMDAmaD00MDAmZm09YXZpZg==.avif
+    </figcaption>
   </figure>
   <footer class="mt-4">
     <hr>

--- a/example/public/index.html
+++ b/example/public/index.html
@@ -25,6 +25,14 @@
       <figcaption>
   </figure>
   <figure>
+    <img src="/.netlify/builders/ipx/f_webp,w_146/https://www.example.com/img/deploy/button.svg" />
+    <figcaption>/.netlify/builders/ipx/f_webp,w_146/img/https://www.example.com/img/deploy/button.svg
+
+
+      will break!
+      <figcaption>
+  </figure>
+  <figure>
     <img
       src="/_gatsby/image/aHR0cHM6Ly9pbWFnZXMudW5zcGxhc2guY29tL3Bob3RvLTE1MTc4NDk4NDU1MzctNGQyNTc5MDI0NTRhP2l4bGliPXJiLTEuMi4xJml4aWQ9TW53eE1qQTNmREI4TUh4d2FHOTBieTF3WVdkbGZIeDhmR1Z1ZkRCOGZIeDgmYXV0bz1mb3JtYXQmZml0PWNyb3Amdz0yMDAwJnE9ODA=/dz0zMDAmaD00MDAmZm09YXZpZg==.avif"
       alt="Gatsby" />

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ export function createIPXHandler ({
 
           const hosts = domains.map(domain => parseURL(domain, 'https://').host)
 
-          if (hosts.find(host => parsedUrl.host === host)) {
+          if (hosts.includes(parsedUrl.host)) {
             domainAllowed = true
           }
         }
@@ -98,6 +98,8 @@ export function createIPXHandler ({
         }
 
         if (!domainAllowed) {
+          console.log(`Domains: ${JSON.stringify(domains)}`)
+          console.log(`RemotePatterns: ${JSON.stringify(remoteURLPatterns)}`)
           return {
             statusCode: 403,
             body: 'URL not on allowlist: ' + id

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,8 +98,10 @@ export function createIPXHandler ({
         }
 
         if (!domainAllowed) {
-          console.log(`Domains: ${JSON.stringify(domains)}`)
-          console.log(`RemotePatterns: ${JSON.stringify(remoteURLPatterns)}`)
+          console.log(`URL not on allowlist. Values provided are:
+            Domains: ${JSON.stringify(domains)}
+            RemotePatterns: ${JSON.stringify(remoteURLPatterns)}
+          `)
           return {
             statusCode: 403,
             body: 'URL not on allowlist: ' + id

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,8 +73,7 @@ export function createIPXHandler ({
       }
 
       if (!bypassDomainCheck) {
-        let domainAllowed = true
-        let remotePatternAllowed = true
+        let domainAllowed = false
 
         if (domains.length > 0) {
           if (typeof domains === 'string') {
@@ -83,8 +82,8 @@ export function createIPXHandler ({
 
           const hosts = domains.map(domain => parseURL(domain, 'https://').host)
 
-          if (!hosts.find(host => parsedUrl.host === host)) {
-            domainAllowed = false
+          if (hosts.find(host => parsedUrl.host === host)) {
+            domainAllowed = true
           }
         }
 
@@ -93,12 +92,12 @@ export function createIPXHandler ({
             return doPatternsMatchUrl(remotePattern, parsedUrl)
           })
 
-          if (!matchingRemotePattern) {
-            remotePatternAllowed = false
+          if (matchingRemotePattern) {
+            domainAllowed = true
           }
         }
 
-        if (!domainAllowed || !remotePatternAllowed) {
+        if (!domainAllowed) {
           return {
             statusCode: 403,
             body: 'URL not on allowlist: ' + id

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,8 +99,8 @@ export function createIPXHandler ({
 
         if (!domainAllowed) {
           console.log(`URL not on allowlist. Values provided are:
-            Domains: ${JSON.stringify(domains)}
-            RemotePatterns: ${JSON.stringify(remoteURLPatterns)}
+            domains: ${JSON.stringify(domains)}
+            remotePatterns: ${JSON.stringify(remoteURLPatterns)}
           `)
           return {
             statusCode: 403,


### PR DESCRIPTION
Logic to include both remotePatterns and domains was broken - if both were present in the config, but only one contained the domain/pattern desired on the allow-list, our function was returning a 403 'URL not on allowlist:'. 

Now we're just using one variable, and changed our initialization.