### PR TITLE
fix: x-forwarded-proto is sanitized now

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,6 @@ export interface IPXHandlerOptions extends Partial<IPXOptions> {
   responseHeaders?: Record<string, string>
 }
 
-const X_FORWARDED_PROTO_VALUES = ['http', 'https']
-
 export function createIPXHandler ({
   cacheDir = join(tmpdir(), 'ipx-cache'),
   basePath = '/_ipx/',
@@ -32,7 +30,7 @@ export function createIPXHandler ({
   }
   const handler: Handler = async (event, _context) => {
     const host = event.headers.host
-    const protocol = event.headers['x-forwarded-proto'] === "https" ? "https" : "http"
+    const protocol = event.headers['x-forwarded-proto'] === 'https' ? 'https' : 'http'
     let domains = (opts as IPXOptions).domains || []
     const remoteURLPatterns = remotePatterns || []
     const requestEtag = event.headers['if-none-match']

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ export function createIPXHandler ({
   }
   const handler: Handler = async (event, _context) => {
     const host = event.headers.host
-    const protocol = event.headers['x-forwarded-proto'] || 'http'
+    const protocol = event.headers['x-nf-connection-proto'] || 'http'
     let domains = (opts as IPXOptions).domains || []
     const remoteURLPatterns = remotePatterns || []
     const requestEtag = event.headers['if-none-match']

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ export interface IPXHandlerOptions extends Partial<IPXOptions> {
   responseHeaders?: Record<string, string>
 }
 
+const X_FORWARDED_PROTO_VALUES = ['http', 'https']
+
 export function createIPXHandler ({
   cacheDir = join(tmpdir(), 'ipx-cache'),
   basePath = '/_ipx/',
@@ -30,6 +32,8 @@ export function createIPXHandler ({
   }
   const handler: Handler = async (event, _context) => {
     const host = event.headers.host
+    event.headers['x-forwarded-proto'] = X_FORWARDED_PROTO_VALUES.includes(event.headers['x-forwarded-proto'].toLowerCase()) ? event.headers['x-forwarded-proto'] : 'http'
+
     const protocol = event.headers['x-forwarded-proto'] || 'http'
     let domains = (opts as IPXOptions).domains || []
     const remoteURLPatterns = remotePatterns || []

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,9 +32,7 @@ export function createIPXHandler ({
   }
   const handler: Handler = async (event, _context) => {
     const host = event.headers.host
-    event.headers['x-forwarded-proto'] = X_FORWARDED_PROTO_VALUES.includes(event.headers['x-forwarded-proto'].toLowerCase()) ? event.headers['x-forwarded-proto'] : 'http'
-
-    const protocol = event.headers['x-forwarded-proto'] || 'http'
+    const protocol = event.headers['x-forwarded-proto'] === "https" ? "https" : "http"
     let domains = (opts as IPXOptions).domains || []
     const remoteURLPatterns = remotePatterns || []
     const requestEtag = event.headers['if-none-match']

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,6 @@ export interface IPXHandlerOptions extends Partial<IPXOptions> {
   responseHeaders?: Record<string, string>
 }
 
-const X_FORWARDED_PROTO_VALUES = ['http', 'https']
-
 export function createIPXHandler ({
   cacheDir = join(tmpdir(), 'ipx-cache'),
   basePath = '/_ipx/',
@@ -32,8 +30,6 @@ export function createIPXHandler ({
   }
   const handler: Handler = async (event, _context) => {
     const host = event.headers.host
-    event.headers['x-forwarded-proto'] = X_FORWARDED_PROTO_VALUES.includes(event.headers['x-forwarded-proto'].toLowerCase()) ? event.headers['x-forwarded-proto'] : 'http'
-
     const protocol = event.headers['x-forwarded-proto'] || 'http'
     let domains = (opts as IPXOptions).domains || []
     const remoteURLPatterns = remotePatterns || []

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ export interface IPXHandlerOptions extends Partial<IPXOptions> {
   responseHeaders?: Record<string, string>
 }
 
+const X_FORWARDED_PROTO_VALUES = ['http', 'https']
+
 export function createIPXHandler ({
   cacheDir = join(tmpdir(), 'ipx-cache'),
   basePath = '/_ipx/',
@@ -30,7 +32,9 @@ export function createIPXHandler ({
   }
   const handler: Handler = async (event, _context) => {
     const host = event.headers.host
-    const protocol = event.headers['x-nf-connection-proto'] || 'http'
+    event.headers['x-forwarded-proto'] = X_FORWARDED_PROTO_VALUES.includes(event.headers['x-forwarded-proto'].toLowerCase()) ? event.headers['x-forwarded-proto'] : 'http'
+
+    const protocol = event.headers['x-forwarded-proto'] || 'http'
     let domains = (opts as IPXOptions).domains || []
     const remoteURLPatterns = remotePatterns || []
     const requestEtag = event.headers['if-none-match']


### PR DESCRIPTION
## Description

Fixes an issue where someone can inject a non-standard value in the `x-forwarded-proto` header.