### PR TITLE
chore: remove old team from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @netlify/frameworks @netlify/ecosystem-pod-frameworks 
+*   @netlify/ecosystem-pod-frameworks 


### PR DESCRIPTION
Updating `CODEOWNERS` to remove the old team name.