### PR TITLE
feat: add prefix filtering and loop detection for local images

### DIFF
--- a/example/netlify/functions/ipx.ts
+++ b/example/netlify/functions/ipx.ts
@@ -10,6 +10,7 @@ export const handler = createIPXHandler({
   domains: [
     'www.netlify.com'
   ],
+  localPrefix: '/img/',
   basePath: '/.netlify/builders/ipx/',
   responseHeaders: {
     'Strict-Transport-Security': 'max-age=31536000',

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepack": "yarn build",
     "lint": "yarn eslint --ext .ts,.js,.mjs src",
     "test": "ava",
-    "dev": "cd example && netlify dev"
+    "dev": "netlify dev"
   },
   "dependencies": {
     "@netlify/functions": "^1.2.0",


### PR DESCRIPTION
Adds support for a `localPrefix` option, ensuring that local images can only be served from a specific path. Additionally, adds a header to prevent infinite loops where the source image matches the ipx server. This is done by adding an `x-ipx-subrequest` header to source image requests. If this header is detected then it means there's a request loop.