### PR TITLE
fix: remove quotes from etag

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
   ],
   "ignorePatterns": "dist",
   "rules": {
-    "import/named": "off"
+    "import/named": "off",
+    "vue/valid-attribute-name": "off"
   }
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -90,7 +90,8 @@ export async function loadSourceImage ({ cacheDir, url, requestEtag, modifiers, 
   // either an etag or a last-modified date for the source image to do so.
   let responseEtag
   if (metadata.etag || metadata.lastModified) {
-    responseEtag = etag(`${cacheKey}${metadata.etag || metadata.lastModified}${modifiers}`)
+    // etag returns a quoted string for some reason
+    responseEtag = JSON.parse(etag(`${cacheKey}${metadata.etag || metadata.lastModified}${modifiers}`))
     if (requestEtag && (requestEtag === responseEtag)) {
       return {
         response: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,7 +189,7 @@ export function createIPXHandler ({
     const body =
       typeof res.body === 'string' ? res.body : res.body.toString('base64')
 
-    res.headers.etag = responseEtag || etag(body)
+    res.headers.etag = responseEtag || JSON.parse(etag(body))
     delete res.headers['Last-Modified']
 
     if (requestEtag && requestEtag === res.headers.etag) {


### PR DESCRIPTION
The `etag()` libary returns a quoted string for some reason. This has been causing issues with the `If-None-Match` header not being recognised in some cases. This PR fixes it by using `JSON.parse` to unquote the string. Fixes https://github.com/netlify/next-runtime/issues/1491

## Review instructions

- Visit [the deploy preview](https://deploy-preview-103--netlify-ipx-demo.netlify.app/)
- Open the top image in a new tab
- Open dev tools network tab, ensuring caching is not disabled
- Reload the image
- Ensure that the request sends an `If-None-Match` header with an unquoted value, and that response is a 304 with an etag that is the same and also unquoted

