### PR TITLE
support query params syntax for gatsby's IMAGE_CDN

### DIFF
--- a/example/netlify/functions/gatsby.ts
+++ b/example/netlify/functions/gatsby.ts
@@ -1,7 +1,7 @@
 import { createIPXHandler } from '@netlify/ipx'
 
 export const handler = createIPXHandler({
-  domains: ['images.unsplash.com'],
+  domains: ['images.unsplash.com', 'wpgatsbydemo.wpengine.com'],
   propsEncoding: 'base64',
   basePath: '/_gatsby/image/'
 })

--- a/example/public/index.html
+++ b/example/public/index.html
@@ -9,7 +9,7 @@
 <body class="m-4">
   <h1 class="text-4xl mb-4">Netlify Optimized Images</h1>
 
-  <figure>
+  <!-- <figure>
     <img src="/.netlify/builders/ipx/f_webp,w_450/img/test.jpg" />
     <figcaption>/.netlify/builders/ipx/f_webp,w_450/img/test.jpg<figcaption>
   </figure>
@@ -39,7 +39,7 @@
 
       will break!
       <figcaption>
-  </figure>
+  </figure> -->
   <figure>
     <img
       src="/_gatsby/image/aHR0cHM6Ly9pbWFnZXMudW5zcGxhc2guY29tL3Bob3RvLTE1MTc4NDk4NDU1MzctNGQyNTc5MDI0NTRhP2l4bGliPXJiLTEuMi4xJml4aWQ9TW53eE1qQTNmREI4TUh4d2FHOTBieTF3WVdkbGZIeDhmR1Z1ZkRCOGZIeDgmYXV0bz1mb3JtYXQmZml0PWNyb3Amdz0yMDAwJnE9ODA=/dz0zMDAmaD00MDAmZm09YXZpZg==.avif"
@@ -48,12 +48,29 @@
       /_gatsby/image/aHR0cHM6Ly9pbWFnZXMudW5zcGxhc2guY29tL3Bob3RvLTE1MTc4NDk4NDU1MzctNGQyNTc5MDI0NTRhP2l4bGliPXJiLTEuMi4xJml4aWQ9TW53eE1qQTNmREI4TUh4d2FHOTBieTF3WVdkbGZIeDhmR1Z1ZkRCOGZIeDgmYXV0bz1mb3JtYXQmZml0PWNyb3Amdz0yMDAwJnE9ODA=/dz0zMDAmaD00MDAmZm09YXZpZg==.avif
     </figcaption>
   </figure>
-  <footer class="mt-4">
+  <figure>
+    <img
+      src="/_gatsby/image/2f51cba0ab2ed65a10e89306263539a3/eba5fe284d4f7ff2d309be2283763099/dsc20050604_133440_34211.jpg?u=https%3A%2F%2Fwpgatsbydemo.wpengine.com%2Fwp-content%2Fuploads%2F2013%2F09%2Fdsc20050604_133440_34211.jpg&amp;a=w%3D160%26h%3D120%26fm%3Djpg%26q%3D75&amp;cd=b7b32a47845b5531a30c96fb5caf18d1"
+      alt="Gatsby 2" />
+    <figcaption>
+      /_gatsby/image/2f51cba0ab2ed65a10e89306263539a3/eba5fe284d4f7ff2d309be2283763099/dsc20050604_133440_34211.jpg?u=https%3A%2F%2Fwpgatsbydemo.wpengine.com%2Fwp-content%2Fuploads%2F2013%2F09%2Fdsc20050604_133440_34211.jpg&amp;a=w%3D160%26h%3D120%26fm%3Djpg%26q%3D75&amp;cd=b7b32a47845b5531a30c96fb5caf18d1
+    </figcaption>
+  </figure>
+    <figure>
+    <img
+      src="/_gatsby/image/2f51cba0ab2ed65a10e89306263539a3/eba5fe284d4f7ff2d309be2283763099/dsc20050604_133440_34211.jpg?u=https%3A%2F%2Fwpgatsbydemo.wpengine.com%2Fwp-content%2Fuploads%2F2013%2F09%2Fdsc20050604_133440_34211.jpg&amp;a=w%3D320%26h%3D240%26fm%3Djpg%26q%3D75&amp;cd=b7b32a47845b5531a30c96fb5caf18d1"
+      alt="Gatsby 3" />
+    <figcaption>
+      /_gatsby/image/2f51cba0ab2ed65a10e89306263539a3/eba5fe284d4f7ff2d309be2283763099/dsc20050604_133440_34211.jpg?u=https%3A%2F%2Fwpgatsbydemo.wpengine.com%2Fwp-content%2Fuploads%2F2013%2F09%2Fdsc20050604_133440_34211.jpg&amp;a=w%3D320%26h%3D240%26fm%3Djpg%26q%3D75&amp;cd=b7b32a47845b5531a30c96fb5caf18d1
+    </figcaption>
+  </figure>
+
+  <!-- <footer class="mt-4">
     <hr>
     Images optimized with
     <a href="https://github.com/unjs/ipx" target="_blank">unjs/ipx</a>
     served by <a href="https://www.netlify.com/products/functions/">Netlify Builder Functions</a>
-  </footer>
+  </footer> -->
 
 </body>
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,5 +8,5 @@ external_node_modules = ["fsevents"]
 
 [[redirects]]
 from = "/_gatsby/image/*"
-to = "/.netlify/builders/gatsby"
+to = "/.netlify/functions/gatsby"
 status = 200

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,12 @@ import { builder, Handler } from '@netlify/functions'
 import { parseURL } from 'ufo'
 import etag from 'etag'
 import { loadSourceImage } from './http'
-import { decodeBase64Params, doPatternsMatchUrl, RemotePattern } from './utils'
+import {
+  decodeBase64Params,
+  doPatternsMatchUrl,
+  RemotePattern,
+  getNormalizedModifers,
+} from './utils'
 export interface IPXHandlerOptions extends Partial<IPXOptions> {
   /**
    * Path to cache directory
@@ -78,7 +83,11 @@ export function createIPXHandler ({
     let [modifiers = '_', ...segments] = eventPath.split('/')
     let id = decodeURIComponent(segments.join('/'))
 
-    if (propsEncoding === 'base64') {
+    const q = new URLSearchParams(event.rawQuery)
+    if (q.has('u')) {
+      id = q.get('u')
+      modifiers = getNormalizedModifers(new URLSearchParams(q.get('a')))
+    } else if (propsEncoding === 'base64') {
       const params = decodeBase64Params(eventPath)
       if (params.error) {
         return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,5 +223,5 @@ export function createIPXHandler ({
     }
   }
 
-  return builder(handler)
+  return handler
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,6 +23,10 @@ export function decodeBase64Params (path:string) {
   }
   const params = new URLSearchParams(transforms)
 
+  return { id, modifiers: getNormalizedModifers(params) }
+}
+
+export function getNormalizedModifers(params: URLSearchParams): string {
   //  [ipx modifier name, gatsby modifier name]
   const props = [
     ['f', 'fm'],
@@ -49,7 +53,7 @@ export function decodeBase64Params (path:string) {
     }
   }
 
-  return { id, modifiers: modifiers.join(',') }
+  return modifiers.join(',')
 }
 
 export interface RemotePattern {


### PR DESCRIPTION
very rough support for newer url syntax of gatsby's IMAGE_CDN ( https://github.com/netlify/pod-ecosystem-frameworks/issues/389 ). New syntax is using query params and this PR in current form is meant to test wether ODB query params stripping and caching will cause problems with the new syntax