### PR TITLE
feat: add pruning mechanism for source images cache

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -56,9 +56,8 @@ const USAGE_TRACKING_KEY = 'usage-tracking'
 const trackingLock = new Lock()
 
 async function getTracking (metadataStore: Storage): Promise<UsageTracking> {
-  return ((await metadataStore.getItem(USAGE_TRACKING_KEY)) as
-      | UsageTracking
-      | undefined) ?? {}
+  return ((await metadataStore.getItem(USAGE_TRACKING_KEY)) ??
+    {}) as UsageTracking
 }
 
 async function markUsageStart (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -85,34 +85,34 @@ export function doPatternsMatchUrl (remotePattern: RemotePattern, parsedUrl: Par
 }
 
 export class Lock {
-  private locked = false
-  private ee = new EventEmitter()
+  #locked = false
+  #ee = new EventEmitter()
 
   acquire (): Promise<void> {
     return new Promise((resolve) => {
       // If nobody has the lock, take it and resolve immediately
-      if (!this.locked) {
+      if (!this.#locked) {
         // Safe because JS doesn't interrupt you on synchronous operations,
         // so no need for compare-and-swap or anything like that.
-        this.locked = true
+        this.#locked = true
         return resolve()
       }
 
       // Otherwise, wait until somebody releases the lock and try again
       const tryAcquire = () => {
-        if (!this.locked) {
-          this.locked = true
-          this.ee.removeListener('release', tryAcquire)
+        if (!this.#locked) {
+          this.#locked = true
+          this.#ee.removeListener('release', tryAcquire)
           return resolve()
         }
       }
-      this.ee.on('release', tryAcquire)
+      this.#ee.on('release', tryAcquire)
     })
   }
 
   release (): void {
     // Release the lock immediately
-    this.locked = false
-    setImmediate(() => this.ee.emit('release'))
+    this.#locked = false
+    setImmediate(() => this.#ee.emit('release'))
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,0 +1,100 @@
+import { createServer } from 'http'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import test from 'ava'
+import { readFile, statSync, emptyDir, readdirSync } from 'fs-extra'
+
+import { createIPXHandler } from '../src/index'
+import { CACHE_PRUNING_THRESHOLD } from '../src/http'
+
+test('source image cache prunning', async (t) => {
+  const filePath = join(__dirname, '..', 'example', 'public', 'img', 'test.jpg')
+  const port = 8125
+
+  const { size } = statSync(filePath)
+
+  const imageCountToReachThreshold = Math.floor(CACHE_PRUNING_THRESHOLD / size) + 1
+
+  // just few more images than needed to reach threshold
+  const imageTestCount = imageCountToReachThreshold + 5
+
+  // we assert success on each tranformation + 2 assertions for cache size
+  t.plan(imageTestCount + 2)
+
+  await new Promise<void>((resolve) => {
+    createServer(function (_request, response) {
+      readFile(filePath, function (error, content) {
+        if (error) {
+          response.writeHead(500)
+          response.end(
+            error.toString()
+          )
+        } else {
+          response.writeHead(200, { 'Content-Type': 'image/jpeg' })
+          response.end(content)
+        }
+      })
+    }).listen(port, () => {
+      resolve()
+    })
+  })
+
+  const cacheDir = join(tmpdir(), 'ipx-cache')
+
+  await emptyDir(cacheDir)
+
+  const handler = createIPXHandler({
+    basePath: '/_ipx/',
+    cacheDir,
+    bypassDomainCheck: true
+  })
+
+  for (let i = 0; i < imageTestCount; i++) {
+    const path = `/_ipx/w_500/${i}.jpg`
+    const response = await handler(
+      {
+        rawUrl: `http://localhost:${port}${path}`,
+        path,
+        headers: {},
+        rawQuery: '',
+        httpMethod: 'GET',
+        queryStringParameters: {},
+        multiValueQueryStringParameters: {},
+        multiValueHeaders: {},
+        isBase64Encoded: false,
+        body: null,
+        netlifyGraphToken: undefined
+      },
+      {
+        functionName: 'ipx',
+        callbackWaitsForEmptyEventLoop: false,
+        functionVersion: '1',
+        invokedFunctionArn: '',
+        awsRequestId: '',
+        logGroupName: '',
+        logStreamName: '',
+        memoryLimitInMB: '',
+        getRemainingTimeInMillis: () => 1000,
+        done: () => {},
+        fail: () => {},
+        succeed: () => {}
+      }
+    )
+    if (response) {
+      t.is(response.statusCode, 200)
+    }
+  }
+
+
+  const cacheSize = readdirSync(join(cacheDir, 'cache')).reduce((acc, filename) => {
+    const { size } = statSync(join(cacheDir, 'cache', filename))
+    return acc + size
+  }, 0)
+
+  t.is(cacheSize, imageCountToReachThreshold * size, 'cache size should be equal to number of images needed to reach threshold * image size')
+  t.not(
+    cacheSize,
+    imageTestCount * size,
+    'cache size should not be equal to number of images * image size if we exceed threshold'
+  )
+})

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,7 +7,7 @@ import { readFile, statSync, emptyDir, readdirSync } from 'fs-extra'
 import { createIPXHandler } from '../src/index'
 import { CACHE_PRUNING_THRESHOLD } from '../src/http'
 
-test('source image cache prunning', async (t) => {
+test('source image cache pruning', async (t) => {
   const filePath = join(__dirname, '..', 'example', 'public', 'img', 'test.jpg')
   const port = 8125
 


### PR DESCRIPTION
Lambdas can be kept warm and be reused for repeated requests. This currently can result in lambdas running out of free disk space because source images are never pruned.

This PR adds a mechanism for pruning, keeping track of which source image were least recently used (LRU) and which image transformations are still in progress. In current state the trigger to potentially prune source images is as follows:

Once source images cache exceed (hardcoded) 50MB we check if there are any non in-progress image transformations. If there are we remove least recently used source image. We repeat that until we are below 50MB of cached source images or there are no more currently unused source images.

Above doesn't guarantee not running into disk space issue and even more so if same lambdas can handle multiple requests concurrently (not sure what's the behavior here), but it should at least reduce possibility of running into free disk issues.

Q: Why just 50MB threshold?
A: Because `sharp` / `vips` can also create tmp files during transformation that can be huge so being conservative with threshold seems prudent thing to do, as that's enough to hold some source images

Q: Why not check for free disk space instead of tracking source image cache size?
A: Because I try not to make assumptions about environment this library runs in. Node.js doesn't have builtin cross platform free disk space checking utils (AFAIK). Few cross platform packages I checked have reported issues about compatibility. So this approach is hopefully the least risky one in terms of introducing regressions.

Addresses https://github.com/netlify/netlify-ipx/issues/45