### PR TITLE
chore: removed netlify graph token from test

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -62,8 +62,7 @@ test('source image cache pruning', async (t) => {
         multiValueQueryStringParameters: {},
         multiValueHeaders: {},
         isBase64Encoded: false,
-        body: null,
-        netlifyGraphToken: undefined
+        body: null
       },
       {
         functionName: 'ipx',
@@ -75,16 +74,15 @@ test('source image cache pruning', async (t) => {
         logStreamName: '',
         memoryLimitInMB: '',
         getRemainingTimeInMillis: () => 1000,
-        done: () => {},
-        fail: () => {},
-        succeed: () => {}
+        done: () => { },
+        fail: () => { },
+        succeed: () => { }
       }
     )
     if (response) {
       t.is(response.statusCode, 200)
     }
   }
-
 
   const cacheSize = readdirSync(join(cacheDir, 'cache')).reduce((acc, filename) => {
     const { size } = statSync(join(cacheDir, 'cache', filename))


### PR DESCRIPTION
Small cleanup while working on #178. Netlify Graph has been sunset.

![CleanShot 2023-07-31 at 16 50 08](https://github.com/netlify/netlify-ipx/assets/833231/937a13a8-5bcc-4a9a-ba31-5fd46fcff496)

<img src="https://media3.giphy.com/media/pPrUNsOY8CDS0/giphy.gif"/>