### PR TITLE
fix: casing now matches what comes in a Netlify function via event.headers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { loadSourceImage as defaultLoadSourceImage } from './http'
 import { decodeBase64Params, doPatternsMatchUrl, RemotePattern } from './utils'
 
 // WAF is Web Application Firewall
-const WAF_BYPASS_TOKEN_HEADER = 'X-Nf-Waf-Bypass-Token'
+const WAF_BYPASS_TOKEN_HEADER = 'x-nf-waf-bypass-token'
 
 export interface IPXHandlerOptions extends Partial<IPXOptions> {
   /**

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -107,7 +107,7 @@ test('should add WAF headers to local images being transformed', async (t) => {
     cacheDir: '/tmp/ipx-cache',
     bypassDomainCheck: true
   }, (sourceImageOptions) => {
-    t.assert(sourceImageOptions.requestHeaders && sourceImageOptions.requestHeaders['X-Nf-Waf-Bypass-Token'] === 'some token')
+    t.assert(sourceImageOptions.requestHeaders && sourceImageOptions.requestHeaders['x-nf-waf-bypass-token'] === 'some token')
 
     return Promise.resolve({ finalize: () => { } } as SourceImageResult)
   })
@@ -116,7 +116,7 @@ test('should add WAF headers to local images being transformed', async (t) => {
     {
       rawUrl: 'http://localhost:3000/some-path',
       path: '/_ipx/w_500/no-file.jpg',
-      headers: { 'X-Nf-Waf-Bypass-Token': 'some token' },
+      headers: { 'x-nf-waf-bypass-token': 'some token' },
       rawQuery: '',
       httpMethod: 'GET',
       queryStringParameters: {},
@@ -135,7 +135,7 @@ test('should not add WAF headers to remote images being transformed', async (t) 
     cacheDir: '/tmp/ipx-cache',
     bypassDomainCheck: true
   }, (sourceImageOptions) => {
-    t.assert(sourceImageOptions.requestHeaders && sourceImageOptions.requestHeaders['X-Nf-Waf-Bypass-Token'] === undefined)
+    t.assert(sourceImageOptions.requestHeaders && sourceImageOptions.requestHeaders['x-nf-waf-bypass-token'] === undefined)
 
     return Promise.resolve({ finalize: () => { } } as SourceImageResult)
   })
@@ -144,7 +144,7 @@ test('should not add WAF headers to remote images being transformed', async (t) 
     {
       rawUrl: 'http://localhost:3000/some-path',
       path: '/_ipx/w_500/https%3A%2F%2Fsome-site.com%2Fno-file.jpg',
-      headers: { 'X-Nf-Waf-Bypass-Token': 'some token' },
+      headers: { 'x-nf-waf-bypass-token': 'some token' },
       rawQuery: '',
       httpMethod: 'GET',
       queryStringParameters: {},
@@ -162,7 +162,7 @@ test('should not add WAF headers to local images if WAF is disabled', async (t) 
     cacheDir: '/tmp/ipx-cache',
     bypassDomainCheck: true
   }, (sourceImageOptions) => {
-    t.assert(sourceImageOptions.requestHeaders && sourceImageOptions.requestHeaders['X-Nf-Waf-Bypass-Token'] === undefined)
+    t.assert(sourceImageOptions.requestHeaders && sourceImageOptions.requestHeaders['x-nf-waf-bypass-token'] === undefined)
 
     return Promise.resolve({ finalize: () => { } } as SourceImageResult)
   })


### PR DESCRIPTION
TLDR; when I tested this last week, I think something was cached giving the impression that my fix worked. I'm still uncertain how things got cached in a way that led me to think it was fixed on a test site of mine, but here's the rest of the fix.

When we handle headers the casing doesn't matter in other parts of our infrastructure, but it appears that headers get normalized to all lowercase names. Not sure why I didn't catch this (hat tip @Hrishikesh-K for suggesting this), but I guess it's been a busy couple of weeks. 😅 

To test this, it really requires the Next.js runtime using the version of `@netlify/ipx` once this gets merged. I've tested it with a release candidate, `@netlify/plugin-nextsjs@4.39.4-rc-waf-fix-0.0.0` on my test site https://nick-waf-ipx-test.netlify.app/, Note that you will receive a 404 if you go to the site. You will need to add your IP to the list of allowed IPs. I can configure this if you'd like to test it.

Relates to https://github.com/netlify/pod-ecosystem-frameworks/issues/592

<img src="https://media1.giphy.com/media/ICOgUNjpvO0PC/giphy.gif"/>